### PR TITLE
Refactor StringCalculator parsing into cleaner components

### DIFF
--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative 'string_calculator/parser/string_parser'
+require_relative 'string_calculator/parser/delimiter_parser'
+require_relative 'string_calculator/parser/input_cleaner'
 require_relative 'string_calculator/calculator'
 require_relative 'string_calculator/runner'
 
@@ -9,7 +11,10 @@ module StringCalculator
 
   class << self
     def add(input)
-      parser = Parser::StringParser.new(input)
+      delimiters = Parser::DelimiterParser.new(input).parse
+      cleaned_input = Parser::InputCleaner.new(input).clean
+
+      parser = Parser::StringParser.new(cleaned_input, delimiters)
       calculator = Calculator.new
 
       Runner.new(parser: parser, calculator: calculator).execute

--- a/lib/string_calculator/parser/delimiter_parser.rb
+++ b/lib/string_calculator/parser/delimiter_parser.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Parses custom delimiters from the input string
+
+module StringCalculator
+  module Parser
+    class DelimiterParser
+      def initialize(input)
+        @input = input
+      end
+
+      def parse
+        delimiters = ["\n"]
+
+        if @input.start_with?('//')
+          delimiters.unshift(@input[2])
+        else
+          delimiters.unshift(',')
+        end
+
+        delimiters.uniq
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/input_cleaner.rb
+++ b/lib/string_calculator/parser/input_cleaner.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#  Cleans the input string by removing custom delimiter definitions.
+module StringCalculator
+  module Parser
+    class InputCleaner
+      def initialize(input)
+        @input = input
+      end
+
+      def clean
+        if @input.start_with?('//')
+          @input.split("\n", 2)[1] || ''
+        else
+          @input
+        end
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/string_parser.rb
+++ b/lib/string_calculator/parser/string_parser.rb
@@ -5,8 +5,9 @@
 module StringCalculator
   module Parser
     class StringParser
-      def initialize(input)
+      def initialize(input, delimiters = [])
         @input = input
+        @delimiters = delimiters
       end
 
       def parse
@@ -16,7 +17,11 @@ module StringCalculator
       private
 
       def splitter
-        /,|\n/
+        if @delimiters.nil? || @delimiters.empty?
+          /,|\n/
+        else
+          Regexp.union(@delimiters)
+        end
       end
     end
   end

--- a/spec/string_calculator/parser/delimiter_parser_spec.rb
+++ b/spec/string_calculator/parser/delimiter_parser_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe StringCalculator::Parser::DelimiterParser do
+  describe '#parse' do
+    it 'parses a string with custom single-character delimiter' do
+      parser = described_class.new("//;\n1;2;3")
+      expect(parser.parse).to eq([';', "\n"])
+    end
+  end
+end

--- a/spec/string_calculator/parser/input_cleaner_spec.rb
+++ b/spec/string_calculator/parser/input_cleaner_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe StringCalculator::Parser::InputCleaner do
+  describe '#clean' do
+    it 'removes custom delimiter definition from the input string' do
+      cleaner = described_class.new("//;\n1;2;3")
+      expect(cleaner.clean).to eq('1;2;3')
+    end
+
+    it 'returns the original string if no custom delimiter is defined' do
+      cleaner = described_class.new('1,2,3')
+      expect(cleaner.clean).to eq('1,2,3')
+    end
+
+    it 'handles empty strings' do
+      cleaner = described_class.new('')
+      expect(cleaner.clean).to eq('')
+    end
+
+    it 'handles strings with only custom delimiter definition' do
+      cleaner = described_class.new("//;\n")
+      expect(cleaner.clean).to eq('')
+    end
+  end
+end

--- a/spec/string_calculator/parser/string_parser_spec.rb
+++ b/spec/string_calculator/parser/string_parser_spec.rb
@@ -26,5 +26,14 @@ RSpec.describe StringCalculator::Parser::StringParser do
       parser = described_class.new("1\n2,3")
       expect(parser.parse).to eq([1, 2, 3])
     end
+
+    context 'with custom delimiter' do
+      let(:delimiters) { [';', "\n"] }
+
+      it 'handles custom single-character delimiters' do
+        parser = described_class.new('1;2;3', delimiters)
+        expect(parser.parse).to eq([1, 2, 3])
+      end
+    end
   end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -27,5 +27,9 @@ RSpec.describe StringCalculator do
     it 'handles new lines as separators' do
       expect(StringCalculator.add("1\n2,3")).to eq(6)
     end
+
+    it 'handles custom single-character delimiters' do
+      expect(StringCalculator.add("//;\n1;2;3")).to eq(6)
+    end
   end
 end


### PR DESCRIPTION
- Introduce DelimiterParser to detect custom delimiters and remove delimiter definitions from input
- Introduce InputCleaner to perform input cleanup before parsing numbers
- Update StringParser to accept delimiters and use Regexp.union when provided
- Wire DelimiterParser and InputCleaner into StringCalculator.add so custom delimiters are parsed and definitions removed before number parsing
- Add specs for DelimiterParser and InputCleaner
- Enhance parser and integration tests to cover custom single-character delimiters