### PR TITLE
refa/strategy-delimiters

### DIFF
--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -5,19 +5,15 @@ require_relative 'string_calculator/parser/delimiter_parser'
 require_relative 'string_calculator/parser/input_cleaner'
 require_relative 'string_calculator/calculator'
 require_relative 'string_calculator/runner'
+require_relative 'string_calculator/addition_service'
 
 module StringCalculator
   VERSION = '0.0.1'
 
   class << self
-    def add(input)
-      delimiters = Parser::DelimiterParser.new(input).parse
-      cleaned_input = Parser::InputCleaner.new(input).clean
-
-      parser = Parser::StringParser.new(cleaned_input, delimiters)
-      calculator = Calculator.new
-
-      Runner.new(parser: parser, calculator: calculator).execute
+    def add(input, service = nil)
+      service ||= AdditionService.new
+      service.add(input)
     end
   end
 end

--- a/lib/string_calculator/addition_service.rb
+++ b/lib/string_calculator/addition_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'component_factory'
+require_relative 'runner'
+
+module StringCalculator
+  class AdditionService
+    def initialize(factory = nil)
+      @factory = factory || ComponentFactory.new
+    end
+
+    def add(input)
+      delimiters = factory.create_delimiter_parser(input).parse
+      cleaned_input = factory.create_input_cleaner(input).clean
+
+      parser = factory.create_string_parser(cleaned_input, delimiters)
+      calculator = factory.create_calculator
+
+      Runner.new(parser: parser, calculator: calculator).execute
+    end
+
+    private
+
+    attr_reader :factory
+  end
+end

--- a/lib/string_calculator/component_factory.rb
+++ b/lib/string_calculator/component_factory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'parser/delimiter_parser'
+require_relative 'parser/input_cleaner'
+require_relative 'parser/string_parser'
+require_relative 'calculator'
+
+module StringCalculator
+  class ComponentFactory
+    def create_delimiter_parser(input)
+      Parser::DelimiterParser.new(input)
+    end
+
+    def create_input_cleaner(input)
+      Parser::InputCleaner.new(input)
+    end
+
+    def create_string_parser(cleaned_input, delimiters)
+      Parser::StringParser.new(cleaned_input, delimiters)
+    end
+
+    def create_calculator
+      Calculator.new
+    end
+  end
+end

--- a/lib/string_calculator/parser/cleaning_strategy.rb
+++ b/lib/string_calculator/parser/cleaning_strategy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module StringCalculator
+  module Parser
+    module CleaningStrategy
+      def applies_to?(input)
+        raise NotImplementedError, 'Subclasses must implement applies_to?'
+      end
+
+      def clean(input)
+        raise NotImplementedError, 'Subclasses must implement clean'
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/custom_delimiter_cleaning_strategy.rb
+++ b/lib/string_calculator/parser/custom_delimiter_cleaning_strategy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'cleaning_strategy'
+
+module StringCalculator
+  module Parser
+    class CustomDelimiterCleaningStrategy
+      include CleaningStrategy
+
+      def applies_to?(input)
+        input.start_with?('//')
+      end
+
+      def clean(input)
+        input.split("\n", 2)[1] || ''
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/custom_delimiter_strategy.rb
+++ b/lib/string_calculator/parser/custom_delimiter_strategy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'delimiter_strategy'
+
+module StringCalculator
+  module Parser
+    class CustomDelimiterStrategy
+      include DelimiterStrategy
+
+      def applies_to?(input)
+        input.start_with?('//')
+      end
+
+      def extract_delimiters(input)
+        custom_delimiter = input[2]
+        [custom_delimiter, "\n"]
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/default_cleaning_strategy.rb
+++ b/lib/string_calculator/parser/default_cleaning_strategy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'cleaning_strategy'
+
+module StringCalculator
+  module Parser
+    class DefaultCleaningStrategy
+      include CleaningStrategy
+
+      def applies_to?(input)
+        !input.start_with?('//')
+      end
+
+      def clean(input)
+        input
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/default_delimiter_strategy.rb
+++ b/lib/string_calculator/parser/default_delimiter_strategy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'delimiter_strategy'
+
+module StringCalculator
+  module Parser
+    class DefaultDelimiterStrategy
+      include DelimiterStrategy
+
+      def applies_to?(input)
+        !input.start_with?('//')
+      end
+
+      def extract_delimiters(_input)
+        [',', "\n"]
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/delimiter_parser.rb
+++ b/lib/string_calculator/parser/delimiter_parser.rb
@@ -1,24 +1,33 @@
 # frozen_string_literal: true
 
-# Parses custom delimiters from the input string
+require_relative 'default_delimiter_strategy'
+require_relative 'custom_delimiter_strategy'
 
 module StringCalculator
   module Parser
     class DelimiterParser
-      def initialize(input)
+      def initialize(input, strategies = nil)
         @input = input
+        @strategies = strategies || default_strategies
       end
 
       def parse
-        delimiters = ["\n"]
+        strategy = find_applicable_strategy
+        strategy.extract_delimiters(@input).uniq
+      end
 
-        if @input.start_with?('//')
-          delimiters.unshift(@input[2])
-        else
-          delimiters.unshift(',')
-        end
+      private
 
-        delimiters.uniq
+      def find_applicable_strategy
+        @strategies.find { |strategy| strategy.applies_to?(@input) } ||
+          raise(ArgumentError, 'No applicable delimiter strategy found')
+      end
+
+      def default_strategies
+        [
+          CustomDelimiterStrategy.new,
+          DefaultDelimiterStrategy.new
+        ]
       end
     end
   end

--- a/lib/string_calculator/parser/delimiter_strategy.rb
+++ b/lib/string_calculator/parser/delimiter_strategy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module StringCalculator
+  module Parser
+    module DelimiterStrategy
+      def applies_to?(input)
+        raise NotImplementedError, 'Subclasses must implement applies_to?'
+      end
+
+      def extract_delimiters(input)
+        raise NotImplementedError, 'Subclasses must implement extract_delimiters'
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/input_cleaner.rb
+++ b/lib/string_calculator/parser/input_cleaner.rb
@@ -1,19 +1,33 @@
 # frozen_string_literal: true
 
-#  Cleans the input string by removing custom delimiter definitions.
+require_relative 'custom_delimiter_cleaning_strategy'
+require_relative 'default_cleaning_strategy'
+
 module StringCalculator
   module Parser
     class InputCleaner
-      def initialize(input)
+      def initialize(input, strategies = nil)
         @input = input
+        @strategies = strategies || default_strategies
       end
 
       def clean
-        if @input.start_with?('//')
-          @input.split("\n", 2)[1] || ''
-        else
-          @input
-        end
+        strategy = find_applicable_strategy
+        strategy.clean(@input)
+      end
+
+      private
+
+      def find_applicable_strategy
+        @strategies.find { |strategy| strategy.applies_to?(@input) } ||
+          raise(ArgumentError, 'No applicable cleaning strategy found')
+      end
+
+      def default_strategies
+        [
+          CustomDelimiterCleaningStrategy.new,
+          DefaultCleaningStrategy.new
+        ]
       end
     end
   end

--- a/spec/string_calculator/addition_service_spec.rb
+++ b/spec/string_calculator/addition_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/string_calculator/addition_service'
+
+RSpec.describe StringCalculator::AdditionService do
+  let(:service) { described_class.new }
+
+  describe '#add' do
+    it 'returns 0 for an empty string' do
+      expect(service.add('')).to eq(0)
+    end
+
+    it 'returns the number for a single number string' do
+      expect(service.add('5')).to eq(5)
+    end
+
+    it 'returns the sum for two comma-separated numbers' do
+      expect(service.add('2,3')).to eq(5)
+    end
+
+    it 'returns the sum for multiple comma-separated numbers' do
+      expect(service.add('1,2,3,4,5')).to eq(15)
+    end
+
+    it 'handles numbers with spaces' do
+      expect(service.add(' 1 , 2 , 3 2 ')).to eq(35)
+    end
+
+    it 'handles new lines as separators' do
+      expect(service.add("1\n2,3")).to eq(6)
+    end
+
+    it 'handles custom single-character delimiters' do
+      expect(service.add("//;\n1;2;3")).to eq(6)
+    end
+  end
+
+  describe 'dependency injection' do
+    let(:mock_factory) { instance_double(StringCalculator::ComponentFactory) }
+    let(:mock_delimiter_parser) { instance_double(StringCalculator::Parser::DelimiterParser) }
+    let(:mock_input_cleaner) { instance_double(StringCalculator::Parser::InputCleaner) }
+    let(:mock_string_parser) { instance_double(StringCalculator::Parser::StringParser) }
+    let(:mock_calculator) { instance_double(StringCalculator::Calculator) }
+    let(:mock_runner) { instance_double(StringCalculator::Runner) }
+
+    let(:service_with_factory) { described_class.new(mock_factory) }
+
+    before do
+      allow(mock_factory).to receive(:create_delimiter_parser).and_return(mock_delimiter_parser)
+      allow(mock_factory).to receive(:create_input_cleaner).and_return(mock_input_cleaner)
+      allow(mock_factory).to receive(:create_string_parser).and_return(mock_string_parser)
+      allow(mock_factory).to receive(:create_calculator).and_return(mock_calculator)
+
+      allow(mock_delimiter_parser).to receive(:parse).and_return([',', "\n"])
+      allow(mock_input_cleaner).to receive(:clean).and_return('1,2,3')
+      allow(StringCalculator::Runner).to receive(:new).and_return(mock_runner)
+      allow(mock_runner).to receive(:execute).and_return(42)
+    end
+
+    it 'uses injected factory to create components' do
+      input = '1,2,3'
+
+      expect(mock_factory).to receive(:create_delimiter_parser).with(input)
+      expect(mock_factory).to receive(:create_input_cleaner).with(input)
+      expect(mock_factory).to receive(:create_string_parser).with('1,2,3', [',', "\n"])
+      expect(mock_factory).to receive(:create_calculator)
+
+      service_with_factory.add(input)
+    end
+
+    it 'returns result from runner execution' do
+      expect(service_with_factory.add('1,2,3')).to eq(42)
+    end
+  end
+
+  describe 'with default factory' do
+    it 'creates default factory when none provided' do
+      expect(StringCalculator::ComponentFactory).to receive(:new).and_call_original
+      described_class.new
+    end
+  end
+end


### PR DESCRIPTION
Summary
- Extract delimiter parsing into DelimiterStrategy interface with CustomDelimiterStrategy and DefaultDelimiterStrategy; DelimiterParser now selects an injectable strategy.
- Introduce CleaningStrategy interface with CustomDelimiterCleaningStrategy and DefaultCleaningStrategy; InputCleaner delegates cleaning to selected strategy and accepts injectable strategies.
- Encapsulate add workflow into AdditionService and ComponentFactory; StringCalculator.add now delegates to AdditionService.
- Add RSpec spec for AdditionService covering addition cases, input cleaning, dependency injection, and default factory behavior.

What changed
- New strategy-based delimiter parsing and input cleaning implementations for SOLID-friendly design.
- AdditionService created to orchestrate delimiter parsing, cleaning, parser/calculator creation, and runner invocation.
- ComponentFactory added to produce parser/calculator components; StringCalculator simplified to delegate to the service.
- Tests: AdditionService spec added.

Notes
- Strategy implementations are injectable for easier testing and extension.
- InputCleaner raises an error if no cleaning strategy applies.