### PR TITLE
feat/sum-number-less-100

### DIFF
--- a/lib/string_calculator/parser/string_parser.rb
+++ b/lib/string_calculator/parser/string_parser.rb
@@ -11,7 +11,13 @@ module StringCalculator
       end
 
       def parse
-        @input.split(splitter).map { |num| num.strip.split.join.to_i }
+        nums = @input.split(splitter).map do |num|
+          num = num.strip.split.join.to_i
+
+          num if num <= 1000
+        end
+
+        nums.compact
       end
 
       private

--- a/spec/string_calculator/parser/string_parser_spec.rb
+++ b/spec/string_calculator/parser/string_parser_spec.rb
@@ -35,5 +35,17 @@ RSpec.describe StringCalculator::Parser::StringParser do
         expect(parser.parse).to eq([1, 2, 3])
       end
     end
+
+    context 'when numbers are bigger than 1000' do
+      it 'includes numbers less than or equal to 1000' do
+        parser = described_class.new('2,1000,6')
+        expect(parser.parse).to eq([2, 1000, 6])
+      end
+
+      it 'ignores numbers greater than 1000' do
+        parser = described_class.new('2,1001,6')
+        expect(parser.parse).to eq([2, 6])
+      end
+    end
   end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -40,5 +40,11 @@ RSpec.describe StringCalculator do
                            'Negatives not allowed: -2, -4')
       end
     end
+
+    context 'when numbers are bigger than 1000' do
+      it 'ignores numbers greater than 1000' do
+        expect(StringCalculator.add('2,1001,6')).to eq(8)
+      end
+    end
   end
 end


### PR DESCRIPTION
Summary
- Ignore numbers greater than 1000 when parsing input and in calculator tests

What changed
- Parser now skips numbers > 1000
- Tests updated ignore numbers > 1000 in parser and calculator tests

Notes
- Behavior: numbers > 1000 are treated as if absent in calculations