### PR TITLE
Refactor parser and calculator to support operators and SOLID design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ group :development do
   gem 'rspec'
   gem 'rubocop', require: false
 end
+
+gem 'pry', '~> 0.15.2', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    coderay (1.1.3)
     diff-lcs (1.6.2)
     json (2.13.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    method_source (1.1.0)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.8.1)
     rack (3.2.0)
     rack-test (2.2.0)
@@ -55,6 +60,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry (~> 0.15.2)
   rack-test
   rake
   rspec

--- a/lib/string_calculator/core/calculator.rb
+++ b/lib/string_calculator/core/calculator.rb
@@ -5,7 +5,32 @@
 module StringCalculator
   class Calculator
     def sum(numbers)
-      numbers.sum
+      numbers.sum do |num|
+        if num.length == 3
+          internal_operate(*num)
+        else
+          num.first
+        end
+      end
+    end
+
+    private
+
+    def internal_operate(num1, operator, num2)
+      case operator
+      when '+'
+        num1 + num2
+      when '-'
+        num1 - num2
+      when '*'
+        num1 * num2
+      when '/'
+        raise ZeroDivisionError, 'Division by zero is not allowed' if num2.zero?
+
+        num1 / num2
+      else
+        raise ArgumentError, "Unsupported operator: #{operator}"
+      end
     end
   end
 end

--- a/lib/string_calculator/parser/operator_parser.rb
+++ b/lib/string_calculator/parser/operator_parser.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# lib/operator_parser.rb
+
+module StringCalculator
+  class OperatorParser
+    def initialize(str)
+      @input = str
+    end
+
+    def parse
+      if (match = @input.match(%r{(?<=\d|\))([+/*-])}))
+        match[1]
+      end
+    end
+  end
+end

--- a/lib/string_calculator/parser/string_parser.rb
+++ b/lib/string_calculator/parser/string_parser.rb
@@ -2,6 +2,8 @@
 
 # lib/string_parser.rb
 
+require_relative 'operator_parser'
+
 module StringCalculator
   module Parser
     class StringParser
@@ -11,16 +13,50 @@ module StringCalculator
       end
 
       def parse
-        nums = @input.split(splitter).map do |num|
-          num = num.strip.split.join.to_i
-
-          num if num <= 1000
-        end
-
-        nums.compact
+        tokens = @input.split(splitter).map { |token| parse_token(token.strip.split.join) }
+        tokens.compact
       end
 
       private
+
+      def parse_token(str)
+        operator = OperatorParser.new(str).parse
+
+        if operator
+          parse_operator_expression(str, operator)
+        else
+          parse_simple_number(str)
+        end
+      end
+
+      def parse_operator_expression(str, operator)
+        numbers = extract_numbers_from_expression(str, operator)
+        return nil if numbers.empty?
+
+        build_operator_result(numbers, operator)
+      end
+
+      def extract_numbers_from_expression(str, operator)
+        str.split(operator_splitter(operator))
+           .map(&:to_i)
+           .select { |num| num <= 1000 }
+      end
+
+      def build_operator_result(numbers, operator)
+        return nil if numbers.empty?
+
+        result = [numbers.first]
+        if numbers.length == 2
+          result << operator
+          result << numbers.last
+        end
+        result
+      end
+
+      def parse_simple_number(str)
+        number = str.to_i
+        number > 1000 ? nil : [number]
+      end
 
       def splitter
         if @delimiters.nil? || @delimiters.empty?
@@ -28,6 +64,10 @@ module StringCalculator
         else
           Regexp.union(@delimiters)
         end
+      end
+
+      def operator_splitter(operator)
+        Regexp.new("\\#{operator}")
       end
     end
   end

--- a/lib/string_calculator/validators/negative_number_validator.rb
+++ b/lib/string_calculator/validators/negative_number_validator.rb
@@ -4,7 +4,15 @@ module StringCalculator
   module Validators
     class NegativeNumberValidator
       def validate!(numbers)
-        negatives = numbers.select(&:negative?)
+        negatives = numbers.map do |nums|
+          negs = []
+
+          negs.push(nums.first) if nums.first.negative?
+          negs.push(nums.last) if nums.length == 3 && nums.last.negative?
+
+          negs
+        end
+        negatives = negatives.flatten
 
         raise NegativeNumberError, negatives unless negatives.empty?
       end

--- a/spec/string_calculator/calculator_spec.rb
+++ b/spec/string_calculator/calculator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StringCalculator::Calculator do
 
   describe '#sum' do
     it 'returns the sum of numbers' do
-      expect(calculator.sum([1, 2, 3])).to eq(6)
+      expect(calculator.sum([[1], [2], [3]])).to eq(6)
     end
 
     it 'returns 0 for empty array' do
@@ -13,11 +13,11 @@ RSpec.describe StringCalculator::Calculator do
     end
 
     it 'handles single number' do
-      expect(calculator.sum([5])).to eq(5)
+      expect(calculator.sum([[5]])).to eq(5)
     end
 
     it 'handles negative numbers' do
-      expect(calculator.sum([-1, 2, -3])).to eq(-2)
+      expect(calculator.sum([[-1], [2], [-3]])).to eq(-2)
     end
   end
 end

--- a/spec/string_calculator/parser/string_parser_spec.rb
+++ b/spec/string_calculator/parser/string_parser_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe StringCalculator::Parser::StringParser do
   describe '#parse' do
     it 'parses a comma-separated string into an array of integers' do
       parser = described_class.new('1,2,3')
-      expect(parser.parse).to eq([1, 2, 3])
+      expect(parser.parse).to eq([[1], [2], [3]])
     end
 
     it 'handles single number strings' do
       parser = described_class.new('5')
-      expect(parser.parse).to eq([5])
+      expect(parser.parse).to eq([[5]])
     end
 
     it 'handles empty strings' do
@@ -19,12 +19,12 @@ RSpec.describe StringCalculator::Parser::StringParser do
 
     it 'handles numbers with spaces' do
       parser = described_class.new(' 1 , 2 , 3 2 ')
-      expect(parser.parse).to eq([1, 2, 32])
+      expect(parser.parse).to eq([[1], [2], [32]])
     end
 
     it 'handles seperators as new lines and commas' do
       parser = described_class.new("1\n2,3")
-      expect(parser.parse).to eq([1, 2, 3])
+      expect(parser.parse).to eq([[1], [2], [3]])
     end
 
     context 'with custom delimiter' do
@@ -32,19 +32,51 @@ RSpec.describe StringCalculator::Parser::StringParser do
 
       it 'handles custom single-character delimiters' do
         parser = described_class.new('1;2;3', delimiters)
-        expect(parser.parse).to eq([1, 2, 3])
+        expect(parser.parse).to eq([[1], [2], [3]])
       end
     end
 
     context 'when numbers are bigger than 1000' do
       it 'includes numbers less than or equal to 1000' do
         parser = described_class.new('2,1000,6')
-        expect(parser.parse).to eq([2, 1000, 6])
+        expect(parser.parse).to eq([[2], [1000], [6]])
       end
 
       it 'ignores numbers greater than 1000' do
         parser = described_class.new('2,1001,6')
-        expect(parser.parse).to eq([2, 6])
+        expect(parser.parse).to eq([[2], [6]])
+      end
+    end
+
+    context 'when input contains operators' do
+      it 'parses addition operator' do
+        parser = described_class.new('1 + 2')
+        expect(parser.parse).to eq([[1, '+', 2]])
+      end
+
+      it 'parses subtraction operator' do
+        parser = described_class.new('5 - 3')
+        expect(parser.parse).to eq([[5, '-', 3]])
+      end
+
+      it 'parses multiplication operator' do
+        parser = described_class.new('4 * 2')
+        expect(parser.parse).to eq([[4, '*', 2]])
+      end
+
+      it 'parses division operator' do
+        parser = described_class.new('8 / 2')
+        expect(parser.parse).to eq([[8, '/', 2]])
+      end
+
+      it 'handles multiple expressions with operators' do
+        parser = described_class.new("1 + 2\n3 * 4")
+        expect(parser.parse).to eq([[1, '+', 2], [3, '*', 4]])
+      end
+
+      it 'ignores numbers greater than 1000 even with operators' do
+        parser = described_class.new('1001 + 2')
+        expect(parser.parse).to eq([[2]])
       end
     end
   end

--- a/spec/string_calculator/runner_spec.rb
+++ b/spec/string_calculator/runner_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe StringCalculator::Runner do
   describe '#execute' do
-    let(:mock_parser) { instance_double(StringCalculator::Parser::StringParser, parse: [1, 2, 3]) }
+    let(:mock_parser) { instance_double(StringCalculator::Parser::StringParser, parse: [[1], [2], [3]]) }
     let(:mock_calculator) { instance_double(StringCalculator::Calculator, sum: 6) }
 
     it 'uses the injected parser to parse input' do
@@ -14,7 +14,7 @@ RSpec.describe StringCalculator::Runner do
     it 'uses injected calculator for computation' do
       runner = described_class.new(parser: mock_parser, calculator: mock_calculator)
       expect(runner.execute).to eq(6)
-      expect(mock_calculator).to have_received(:sum).with([1, 2, 3])
+      expect(mock_calculator).to have_received(:sum).with([[1], [2], [3]])
     end
   end
 end

--- a/spec/string_calculator/validators/negative_number_validator_spec.rb
+++ b/spec/string_calculator/validators/negative_number_validator_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe StringCalculator::Validators::NegativeNumberValidator do
 
     context 'when there are no negative numbers' do
       it 'does not raise an error' do
-        expect { validator.validate!([1, 2, 3]) }.not_to raise_error
+        expect { validator.validate!([[1], [2], [3]]) }.not_to raise_error
       end
     end
 
     context 'when there are negative numbers' do
       it 'raises a NegativeNumberError with the negative numbers' do
-        expect { validator.validate!([1, -2, 3, -4]) }
+        expect { validator.validate!([[1], [-2], [3], [-4]]) }
           .to raise_error(StringCalculator::NegativeNumberError, 'Negatives not allowed: -2, -4')
       end
     end
 
     context 'when all numbers are negative' do
       it 'raises a NegativeNumberError with all the negative numbers' do
-        expect { validator.validate!([-1, -2, -3]) }
+        expect { validator.validate!([[-1], [-2], [-3]]) }
           .to raise_error(StringCalculator::NegativeNumberError, 'Negatives not allowed: -1, -2, -3')
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe StringCalculator::Validators::NegativeNumberValidator do
 
     context 'when there are zero and positive numbers' do
       it 'does not raise an error' do
-        expect { validator.validate!([0, 1, 2]) }.not_to raise_error
+        expect { validator.validate!([[0], [1], [2]]) }.not_to raise_error
       end
     end
   end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -62,5 +62,11 @@ RSpec.describe StringCalculator do
         expect(StringCalculator.add("//[**][%%]\n1**2%%3")).to eq(6)
       end
     end
+
+    context 'handles other calculation operations' do
+      it 'should run the calculations' do
+        expect(StringCalculator.add('2*13,1')).to eq(27)
+      end
+    end
   end
 end


### PR DESCRIPTION
Refactor StringCalculatorals to follow SOLID principles and address RuboCop warnings by: adding an OperatorParser, restructuring StringParser to return tokenized expressions (simple numbers or [num, operator, num]), and moving operator-handling logic out of the Calculator into clear private methods. Update Calculator to interpret operator tokens and handle division-by-zero and unsupported operators. Adjust validators, specs, and Gemfile (add pry) to reflect the new token shape and new behavior. These changes separate responsibilities (parsing vs calculation), improve test coverage for arithmetic operators, and fix style/lint issues.

- Add OperatorParser to extract operators from expressions
- Change StringParser to return tokens: simple numbers or [num, operator, num]
- Move operator-handling logic out of Calculator core into private helper methods
- Update Calculator to interpret operator tokens and handle division-by-zero
- Add handling for unsupported operators with appropriate errors
- Adjust validators to accept new token shapes
- Update specs to cover arithmetic operators and new behaviors
- Update Gemfile (add pry) and address RuboCop warnings and style issues